### PR TITLE
Added support to SharedWorker second parameter be an object and removed unused console.log

### DIFF
--- a/src/caller.ts
+++ b/src/caller.ts
@@ -13,7 +13,7 @@ import {
 export class TabsManagerWorkerCaller extends EventEmitter {
   private readonly workerPath: string;
 
-  private readonly workerName: string;
+  private readonly workerOptions: string | Record<string, unknown>;
 
   private workerInstance: SharedWorker;
 
@@ -27,7 +27,7 @@ export class TabsManagerWorkerCaller extends EventEmitter {
     if (!this.workerPath || typeof this.workerPath !== 'string') {
       this.error('Required workerPath parameters missed!');
     }
-    this.workerName = options.workerName ?? 'Tab Manager';
+    this.workerOptions = options.workerOptions ?? 'Tab Manager';
     this.id = uuid();
   }
 
@@ -42,12 +42,11 @@ export class TabsManagerWorkerCaller extends EventEmitter {
       this.error('ShareWorker not support!');
       return;
     }
-    this.workerInstance = new SharedWorker(this.workerPath, this.workerName);
+    this.workerInstance = new SharedWorker(this.workerPath, this.workerOptions);
   }
 
   private initWorkerListener() {
     this.workerInstance.port.addEventListener('message', (e: MessageEvent) => {
-      console.log('eeee', e);
       const { type, id } = e.data;
       if (type === workerEvents.activeTabId) {
         const isActive = id === this.id;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,6 +1,6 @@
 export interface TabsManagerWorkerCallerParams {
   workerPath: string
-  workerName?: string
+  workerOptions?: string | Record<string, unknown>
 }
 
 export interface IWorkerMessageData {


### PR DESCRIPTION
Nice project @Hazyzh ! Exactly what I was looking for!

- I removed this console.log 'eee' which seems a bit annoying 
- Added support for the second parameter to be an object since we can have more options in a vite project: https://v3.vitejs.dev/guide/features.html#web-workers

I can revert the second parameter thing but removing console.log would be really important.

Thanks!