### PR TITLE
Fix firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabs-manager",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Definition one active tab on multiple tabs scenarios. ",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/caller.ts
+++ b/src/caller.ts
@@ -67,7 +67,11 @@ export class TabsManagerWorkerCaller extends EventEmitter {
     if (!this.workerInstance) return;
 
     window.addEventListener('focus', this.setActiveTab);
-    document.addEventListener('visibilitychange', this.setActiveTab);
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState !== 'hidden') {
+        this.setActiveTab();
+      }
+    });
     window.addEventListener('unload', this.closeWindow);
 
     if (document.visibilityState === 'visible') {


### PR DESCRIPTION
Hey @Hazyzh,
found an issue with firefox when changing tabs it triggers the event **visibilitychange** with state **hidden** so it ends locking the main tab as not active.

I updated package json version... Let me know if that helps you save time.